### PR TITLE
Add reserved namespace types

### DIFF
--- a/tests/test_models/test_reserved_namespaces.py
+++ b/tests/test_models/test_reserved_namespaces.py
@@ -1,0 +1,127 @@
+import time
+from datetime import datetime
+
+import zenoh
+
+from tide.namespaces import (
+    CmdTopic,
+    StateTopic,
+    SensorTopic,
+    sensor_camera_rgb,
+    sensor_camera_depth,
+)
+from tide.models import (
+    Vector2,
+    Vector3,
+    Quaternion,
+    Twist2D,
+    Pose2D,
+    Pose3D,
+    LaserScan,
+    Image,
+)
+from tide.models.serialization import to_zenoh_value, from_zenoh_value
+
+
+def _roundtrip(session: zenoh.Session, key: str, msg, model_cls):
+    samples = []
+    sub = session.declare_subscriber(key, lambda s: samples.append(s))
+    pub = session.declare_publisher(key)
+    pub.put(to_zenoh_value(msg))
+    end = time.time() + 0.5
+    while not samples and time.time() < end:
+        time.sleep(0.05)
+    assert samples, f"no sample received for {key}"
+    payload = samples[0].payload
+    if hasattr(payload, "to_bytes"):
+        payload = payload.to_bytes()
+    received = from_zenoh_value(payload, model_cls)
+    sub.undeclare()
+    pub.undeclare()
+    return received
+
+
+def test_reserved_namespace_roundtrip():
+    zenoh.init_log_from_env_or("error")
+    session = zenoh.open(zenoh.Config())
+    try:
+        robot = "testbot"
+        cases = [
+            (
+                CmdTopic.TWIST,
+                Twist2D(
+                    linear=Vector2(x=1.0, y=2.0),
+                    angular=0.1,
+                    timestamp=datetime(2020, 1, 1),
+                ),
+            ),
+            (
+                CmdTopic.POSE2D,
+                Pose2D(x=1.0, y=2.0, theta=0.5, timestamp=datetime(2020, 1, 1)),
+            ),
+            (
+                CmdTopic.POSE3D,
+                Pose3D(
+                    position=Vector3(x=1.0, y=2.0, z=3.0),
+                    orientation=Quaternion(x=0.0, y=0.0, z=0.0, w=1.0),
+                    timestamp=datetime(2020, 1, 1),
+                ),
+            ),
+            (
+                StateTopic.POSE2D,
+                Pose2D(x=0.0, y=1.0, theta=2.0, timestamp=datetime(2020, 1, 2)),
+            ),
+            (
+                StateTopic.POSE3D,
+                Pose3D(
+                    position=Vector3(x=0.0, y=1.0, z=2.0),
+                    orientation=Quaternion(x=0.0, y=0.0, z=0.0, w=1.0),
+                    timestamp=datetime(2020, 1, 2),
+                ),
+            ),
+            (
+                StateTopic.TWIST,
+                Twist2D(
+                    linear=Vector2(x=0.0, y=0.0),
+                    angular=1.0,
+                    timestamp=datetime(2020, 1, 2),
+                ),
+            ),
+            (
+                SensorTopic.LIDAR_SCAN,
+                LaserScan(
+                    angle_min=0.0,
+                    angle_max=1.0,
+                    angle_increment=0.1,
+                    time_increment=0.0,
+                    scan_time=0.1,
+                    range_min=0.0,
+                    range_max=5.0,
+                    ranges=[1.0, 2.0],
+                    intensities=[0.0, 1.0],
+                ),
+            ),
+            (
+                SensorTopic.IMU_ACCEL,
+                Vector3(x=0.1, y=0.2, z=0.3),
+            ),
+        ]
+
+        for topic, msg in cases:
+            key = f"{robot}/{topic.value}"
+            received = _roundtrip(session, key, msg, type(msg))
+            assert received == msg
+
+        # Camera topics with helper functions
+        img = Image(height=1, width=1, encoding="rgb8", step=3, data=b"abc")
+        key = f"{robot}/" + sensor_camera_rgb("front")
+        received = _roundtrip(session, key, img, Image)
+        assert received == img
+
+        img = Image(height=1, width=1, encoding="rgb8", step=3, data=b"def")
+        key = f"{robot}/" + sensor_camera_depth("front")
+        received = _roundtrip(session, key, img, Image)
+        assert received == img
+    finally:
+        session.close()
+

--- a/tide/__init__.py
+++ b/tide/__init__.py
@@ -8,4 +8,24 @@ on top of Zenoh for building robot control systems.
 __version__ = "0.1.0"
 
 # Import core components
-from tide.core.node import BaseNode 
+from tide.core.node import BaseNode
+
+# Reserved namespace enums and helpers
+from tide.namespaces import (
+    Group,
+    CmdTopic,
+    StateTopic,
+    SensorTopic,
+    sensor_camera_rgb,
+    sensor_camera_depth,
+)
+
+__all__ = [
+    "BaseNode",
+    "Group",
+    "CmdTopic",
+    "StateTopic",
+    "SensorTopic",
+    "sensor_camera_rgb",
+    "sensor_camera_depth",
+]

--- a/tide/namespaces.py
+++ b/tide/namespaces.py
@@ -1,0 +1,86 @@
+from enum import Enum
+from typing import Type, Dict
+
+from tide.models import (
+    Twist2D,
+    Pose2D,
+    Pose3D,
+    Vector3,
+    LaserScan,
+    Image,
+)
+
+
+class Group(str, Enum):
+    """Reserved top-level groups."""
+
+    CMD = "cmd"
+    STATE = "state"
+    SENSOR = "sensor"
+    MANIPULATOR = "manipulator"
+
+
+class CmdTopic(str, Enum):
+    """Reserved command topics."""
+
+    TWIST = "cmd/twist"
+    POSE2D = "cmd/pose2d"
+    POSE3D = "cmd/pose3d"
+
+
+CMD_TYPES: Dict[CmdTopic, Type] = {
+    CmdTopic.TWIST: Twist2D,
+    CmdTopic.POSE2D: Pose2D,
+    CmdTopic.POSE3D: Pose3D,
+}
+
+
+class StateTopic(str, Enum):
+    """Reserved state topics."""
+
+    POSE2D = "state/pose2d"
+    POSE3D = "state/pose3d"
+    TWIST = "state/twist"
+
+
+STATE_TYPES: Dict[StateTopic, Type] = {
+    StateTopic.POSE2D: Pose2D,
+    StateTopic.POSE3D: Pose3D,
+    StateTopic.TWIST: Twist2D,
+}
+
+
+class SensorTopic(str, Enum):
+    """Reserved sensor topics."""
+
+    LIDAR_SCAN = "sensor/lidar/scan"
+    IMU_ACCEL = "sensor/imu/accel"
+
+
+SENSOR_TYPES: Dict[SensorTopic, Type] = {
+    SensorTopic.LIDAR_SCAN: LaserScan,
+    SensorTopic.IMU_ACCEL: Vector3,
+}
+
+
+def sensor_camera_rgb(camera_id: str) -> str:
+    """Return the RGB camera topic for the given camera id."""
+    return f"sensor/camera/{camera_id}/rgb"
+
+
+def sensor_camera_depth(camera_id: str) -> str:
+    """Return the depth camera topic for the given camera id."""
+    return f"sensor/camera/{camera_id}/depth"
+
+
+__all__ = [
+    "Group",
+    "CmdTopic",
+    "StateTopic",
+    "SensorTopic",
+    "CMD_TYPES",
+    "STATE_TYPES",
+    "SENSOR_TYPES",
+    "sensor_camera_rgb",
+    "sensor_camera_depth",
+]


### PR DESCRIPTION
## Summary
- add enums for reserved namespaces in `tide.namespaces`
- re-export enums in package `__init__`
- test serialization/deserialization for all reserved topics

## Testing
- `uv run pytest -q`