### PR TITLE
Fix CLI init command and cover pingpong paths

### DIFF
--- a/tests/test_cli/test_cli.py
+++ b/tests/test_cli/test_cli.py
@@ -5,6 +5,7 @@ from unittest import mock
 import pytest
 
 from tide.cli.main import create_parser
+from tide.cli.commands.init import cmd_init
 from tide.cli.commands.init_pingpong import cmd_init_pingpong
 from tide.cli.commands.init_config import cmd_init_config
 from tide.cli.commands.status import cmd_status
@@ -28,12 +29,32 @@ def test_cmd_init_pingpong(tmp_path, monkeypatch):
     assert (tmp_path / 'pong_node.py').exists()
 
 
+def test_cmd_init_pingpong_outside_cwd(tmp_path):
+    args = argparse.Namespace(robot_id='r1', force=False, output_dir=str(tmp_path), create_config=True)
+    result = cmd_init_pingpong(args)
+    assert result == 0
+    assert (tmp_path / 'ping_node.py').exists()
+    assert (tmp_path / 'pong_node.py').exists()
+    assert (tmp_path / 'config' / 'pingpong_config.yaml').exists()
+
+
 def test_cmd_init_config(tmp_path):
     cfg = tmp_path / 'config.yaml'
     args = argparse.Namespace(output=str(cfg), robot_id='r1', force=False, include_node=False)
     result = cmd_init_config(args)
     assert result == 0
     assert cfg.exists()
+
+
+def test_cmd_init_creates_project(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    args = argparse.Namespace(project_name='proj', robot_id='r1', force=False)
+    result = cmd_init(args)
+    assert result == 0
+    proj_dir = tmp_path / 'proj'
+    assert (proj_dir / 'ping_node.py').exists()
+    assert (proj_dir / 'pong_node.py').exists()
+    assert (proj_dir / 'config' / 'config.yaml').exists()
 
 
 def test_cmd_status(monkeypatch, capsys):

--- a/tide/cli/commands/init_pingpong.py
+++ b/tide/cli/commands/init_pingpong.py
@@ -135,11 +135,14 @@ robots:
     console.print("\n[bold green]Ping-Pong example created successfully![/bold green]")
     if hasattr(args, 'create_config') and args.create_config:
         console.print("\nYou can run your ping-pong example with:")
-        console.print(f"[cyan]   tide up --config {config_path.relative_to(Path.cwd())}[/cyan]")
+        rel_config = os.path.relpath(config_path, Path.cwd())
+        console.print(f"[cyan]   tide up --config {rel_config}[/cyan]")
     else:
         console.print("\nTo run the nodes manually:")
         console.print(f"[cyan]   # Run these in separate terminals:[/cyan]")
-        console.print(f"[cyan]   python {ping_path.relative_to(Path.cwd())}[/cyan]")
-        console.print(f"[cyan]   python {pong_path.relative_to(Path.cwd())}[/cyan]")
+        rel_ping = os.path.relpath(ping_path, Path.cwd())
+        rel_pong = os.path.relpath(pong_path, Path.cwd())
+        console.print(f"[cyan]   python {rel_ping}[/cyan]")
+        console.print(f"[cyan]   python {rel_pong}[/cyan]")
     
     return 0 

--- a/tide/cli/main.py
+++ b/tide/cli/main.py
@@ -7,7 +7,13 @@ import argparse
 
 from tide import __version__
 from tide.cli.utils import print_banner
-from tide.cli.commands import cmd_up, cmd_status, cmd_init_pingpong
+from tide.cli.commands import (
+    cmd_init,
+    cmd_up,
+    cmd_status,
+    cmd_init_config,
+    cmd_init_pingpong,
+)
 
 
 def create_parser() -> argparse.ArgumentParser:
@@ -45,6 +51,22 @@ def create_parser() -> argparse.ArgumentParser:
     )
     init_config_parser.add_argument("--force", action="store_true", help="Overwrite existing file")
 
+    init_pingpong_parser = subparsers.add_parser(
+        "init-pingpong", help="Create ping-pong example nodes"
+    )
+    init_pingpong_parser.add_argument(
+        "--output-dir", default=".", help="Directory to create the nodes in"
+    )
+    init_pingpong_parser.add_argument(
+        "--robot-id", default="myrobot", help="Default robot ID to use"
+    )
+    init_pingpong_parser.add_argument(
+        "--force", action="store_true", help="Overwrite existing files"
+    )
+    init_pingpong_parser.add_argument(
+        "--create-config", action="store_true", help="Create a config file for the examples"
+    )
+
     up_parser = subparsers.add_parser("up", help="Run a Tide project")
     up_parser.add_argument(
         "--config", default="config/config.yaml", help="Path to configuration file"
@@ -75,13 +97,21 @@ def main(argv=None):
     # Execute command
     try:
         if args.command == 'init':
+            result = cmd_init(args)
+            sys.exit(result)
+
+        elif args.command == 'init-config':
+            result = cmd_init_config(args)
+            sys.exit(result)
+
+        elif args.command == 'init-pingpong':
             result = cmd_init_pingpong(args)
             sys.exit(result)
-                    
+
         elif args.command == 'up':
             result = cmd_up(args)
             sys.exit(result)
-            
+
         elif args.command == 'status':
             result = cmd_status(args)
             sys.exit(result)


### PR DESCRIPTION
## Summary
- wire `tide init` to the proper command
- expose `init-config` and `init-pingpong` in the CLI
- avoid path errors in `init-pingpong` instructions
- test project creation and pingpong command outside cwd

## Testing
- `uv run pytest -q`