### PR TITLE
Use reserved namespace enums in examples

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -403,6 +403,7 @@ from datetime import datetime
 from tide.core.node import BaseNode
 from tide.models.common import LaserScan, Vector3
 from tide.models.serialization import to_zenoh_value
+from tide import SensorTopic
 
 class SensorNode(BaseNode):
     """
@@ -441,7 +442,7 @@ class SensorNode(BaseNode):
         )
         
         # Publish scan data
-        self.put("lidar/scan", to_zenoh_value(scan))
+        self.put(SensorTopic.LIDAR_SCAN.value, to_zenoh_value(scan))
         
         # Also publish a simple acceleration
         accel = Vector3(
@@ -450,7 +451,7 @@ class SensorNode(BaseNode):
             z=9.8 + random.uniform(-0.1, 0.1)
         )
         
-        self.put("imu/accel", to_zenoh_value(accel))
+        self.put(SensorTopic.IMU_ACCEL.value, to_zenoh_value(accel))
 ```
 
 2. Add the sensor node to your configuration:

--- a/tide/cli/templates/nodes/monitor_node.py.template
+++ b/tide/cli/templates/nodes/monitor_node.py.template
@@ -10,6 +10,7 @@ from datetime import datetime
 from tide.core.node import BaseNode
 from tide.models.common import Pose2D
 from tide.models.serialization import from_zenoh_value
+from tide import StateTopic
 
 
 class MonitorNode(BaseNode):
@@ -27,7 +28,7 @@ class MonitorNode(BaseNode):
         self.last_pose_time = None
         
         # Subscribe to robot state
-        self.subscribe("state/pose2d", self._on_pose)
+        self.subscribe(StateTopic.POSE2D.value, self._on_pose)
         
         print(f"MonitorNode started for robot {{self.ROBOT_ID}}")
     

--- a/tide/cli/templates/nodes/robot_node.py.template
+++ b/tide/cli/templates/nodes/robot_node.py.template
@@ -11,6 +11,7 @@ from datetime import datetime
 from tide.core.node import BaseNode
 from tide.models.common import Twist2D, Pose2D
 from tide.models.serialization import to_zenoh_value, from_zenoh_value
+from tide import CmdTopic, StateTopic
 
 
 class RobotNode(BaseNode):
@@ -34,7 +35,7 @@ class RobotNode(BaseNode):
         self.last_update = time.time()
         
         # Subscribe to command velocity
-        self.subscribe("cmd/twist", self._on_cmd_vel)
+        self.subscribe(CmdTopic.TWIST.value, self._on_cmd_vel)
         
         print(f"RobotNode started for robot {{self.ROBOT_ID}}")
     
@@ -66,4 +67,4 @@ class RobotNode(BaseNode):
         
         # Publish the current pose
         pose = Pose2D(x=self.x, y=self.y, theta=self.theta)
-        await self.put("state/pose2d", to_zenoh_value(pose)) 
+        await self.put(StateTopic.POSE2D.value, to_zenoh_value(pose))

--- a/tide/cli/templates/nodes/teleop_node.py.template
+++ b/tide/cli/templates/nodes/teleop_node.py.template
@@ -11,6 +11,7 @@ from datetime import datetime
 from tide.core.node import BaseNode
 from tide.models.common import Twist2D, Vector2
 from tide.models.serialization import to_zenoh_value
+from tide import CmdTopic
 
 
 class TeleopNode(BaseNode):
@@ -52,5 +53,5 @@ class TeleopNode(BaseNode):
             angular=self.angular_vel
         )
         
-        await self.put("cmd/twist", to_zenoh_value(cmd))
+        await self.put(CmdTopic.TWIST.value, to_zenoh_value(cmd))
         print(f"Sent command: linear={{self.linear_vel:.2f}}, angular={{self.angular_vel:.2f}}") 

--- a/tide/examples/sensor_node.py
+++ b/tide/examples/sensor_node.py
@@ -13,6 +13,7 @@ from datetime import datetime
 from tide.core.node import BaseNode
 from tide.models.common import LaserScan, Vector3
 from tide.models.serialization import to_zenoh_value, from_zenoh_value
+from tide import SensorTopic
 
 
 class SensorNode(BaseNode):
@@ -125,11 +126,11 @@ class SensorNode(BaseNode):
         scan = self.simulate_lidar(robot_x, robot_y, robot_theta)
         
         # Publish scan data
-        await self.put("lidar/scan", to_zenoh_value(scan))
+        await self.put(SensorTopic.LIDAR_SCAN.value, to_zenoh_value(scan))
         
         # Simulate and publish IMU data
         accel = self.simulate_imu()
-        await self.put("imu/accel", to_zenoh_value(accel))
+        await self.put(SensorTopic.IMU_ACCEL.value, to_zenoh_value(accel))
         
 
 class SensorProcessorNode(BaseNode):
@@ -149,8 +150,8 @@ class SensorProcessorNode(BaseNode):
         self.last_accel_time = None
         
         # Subscribe to sensor data
-        self.subscribe("sensor/lidar/scan", self._on_scan)
-        self.subscribe("sensor/imu/accel", self._on_accel)
+        self.subscribe(SensorTopic.LIDAR_SCAN.value, self._on_scan)
+        self.subscribe(SensorTopic.IMU_ACCEL.value, self._on_accel)
         
         print(f"SensorProcessorNode started for robot {self.ROBOT_ID}")
     


### PR DESCRIPTION
## Summary
- use `CmdTopic`, `StateTopic`, and `SensorTopic` enums in example code
- show the enums in docs CLI example
- update CLI templates to use enums for reserved namespaces

## Testing
- `uv run pytest`