### PR TITLE
Fix tide status discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ To discover running Tide nodes on the network:
 tide status
 ```
 
-This shows a list of all discovered Tide nodes, including:
+This shows a list of all discovered Tide nodes. The discovery uses the
+`*/*/*` wildcard so custom groups like the ping-pong example are also found.
+The output includes:
 - Robot ID
 - Group
 - Topic

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -167,7 +167,9 @@ tide up --config custom_config.yaml
 
 ### `status` Command
 
-The `status` command discovers and displays information about running Tide nodes on the network.
+The `status` command discovers and displays information about running Tide nodes
+on the network. Discovery now queries all groups (`*/*/*`), so even nodes that
+only publish custom topics like the ping-pong example will be listed.
 
 ```bash
 tide status [options]

--- a/tide/cli/utils.py
+++ b/tide/cli/utils.py
@@ -97,16 +97,18 @@ def discover_nodes(timeout: float = 2.0) -> List[Dict[str, Any]]:
     """
     # Create a zenoh session for discovery
     z = zenoh.open(zenoh.Config())
-    
-    # Query for nodes
+
+    # Query for nodes across all groups
     discovered_nodes = []
     
     # Wait for responses
     start_time = time.time()
     
     try:
-        # Query for anything in the */state/* namespace
-        replies = z.get("*/state/*")
+        # Query for anything matching the robot_id/group/topic pattern
+        # This allows discovery of nodes even if they don't publish to the
+        # reserved "state" group.
+        replies = z.get("*/*/*")
         
         while time.time() - start_time < timeout:
             # Process any new replies


### PR DESCRIPTION
## Summary
- broaden zenoh query so `tide status` discovers all groups
- document the new discovery behaviour in README and CLI docs

## Testing
- `bash install-deps.bash`
- `uv run pytest -q`