### PR TITLE
Improve test coverage

### DIFF
--- a/tests/test_cli/test_cli.py
+++ b/tests/test_cli/test_cli.py
@@ -57,6 +57,19 @@ def test_cmd_init_config(tmp_path):
     assert cfg.exists()
 
 
+def test_cmd_init_config_with_nodes(tmp_path):
+    cfg_dir = tmp_path / "config"
+    cfg_dir.mkdir()
+    cfg = cfg_dir / "config.yaml"
+    args = argparse.Namespace(output=str(cfg), robot_id='r1', force=False, include_node=True)
+    result = cmd_init_config(args)
+    assert result == 0
+    assert cfg.exists()
+    # nodes should be created alongside the config parent directory
+    assert (tmp_path / 'ping_node.py').exists()
+    assert (tmp_path / 'pong_node.py').exists()
+
+
 def test_cmd_init_creates_project(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     args = argparse.Namespace(project_name='proj', robot_id='r1', force=False)

--- a/tests/test_core/test_geometry_no_numpy.py
+++ b/tests/test_core/test_geometry_no_numpy.py
@@ -1,0 +1,18 @@
+import math
+import pytest
+
+import tide.core.geometry as geom
+
+
+def test_quaternion_roundtrip_no_numpy():
+    q = geom.Quaternion.from_euler(0.1, -0.2, 0.3)
+    r, p, y = q.to_euler()
+    assert math.isclose(r, 0.1, abs_tol=1e-6)
+    assert math.isclose(p, -0.2, abs_tol=1e-6)
+    assert math.isclose(y, 0.3, abs_tol=1e-6)
+
+
+def test_ensure_numpy_raises(monkeypatch):
+    monkeypatch.setattr(geom, "np", None)
+    with pytest.raises(ImportError):
+        geom._ensure_numpy()

--- a/tests/test_models/test_serialization_utils.py
+++ b/tests/test_models/test_serialization_utils.py
@@ -1,0 +1,32 @@
+import json
+from pydantic import BaseModel
+
+from tide.models.serialization import to_json, to_dict, to_zenoh_value, from_zenoh_value
+
+
+class DummyModel(BaseModel):
+    x: int
+    y: str
+
+
+def test_serialization_roundtrip():
+    obj = DummyModel(x=1, y="a")
+    json_str = to_json(obj)
+    data = json.loads(json_str)
+    assert data == {"x": 1, "y": "a"}
+
+    as_dict = to_dict(obj)
+    assert as_dict == {"x": 1, "y": "a"}
+
+    val = to_zenoh_value(obj)
+    assert isinstance(val, bytes)
+
+    restored = from_zenoh_value(val, DummyModel)
+    assert restored == obj
+
+
+def test_from_zenoh_value_dict():
+    data = {"a": 1}
+    val = to_zenoh_value(data)
+    restored = from_zenoh_value(val, dict)
+    assert restored == data


### PR DESCRIPTION
## Summary
- add new test for `cmd_init_config` to exercise `--include-node`
- add pure Python geometry tests when numpy is absent
- add serialization helper tests

## Testing
- `uv run pytest --cov=tide --cov-report=term-missing`