### PR TITLE
Add CBOR serialization support

### DIFF
--- a/tests/test_core/test_node.py
+++ b/tests/test_core/test_node.py
@@ -119,8 +119,7 @@ class TestBaseNode:
         # At this point, our BaseNode's _latest_values should have the Zenoh sample
         # Test take which consumes the value
         taken_value = node.take("test_topic")
-        assert taken_value is not None
-        assert hasattr(taken_value, 'payload')
+        assert taken_value == test_value
         
         # Take again should now be None
         empty_value = node.take("test_topic")

--- a/tests/test_models/test_serialization_cbor.py
+++ b/tests/test_models/test_serialization_cbor.py
@@ -1,0 +1,23 @@
+import pytest
+from tide.models import Pose2D, encode_message, decode_message, to_zenoh_value, from_zenoh_value
+
+
+def test_cbor_helpers_roundtrip():
+    msg = Pose2D(x=1.0, y=2.0, theta=0.5)
+    data = encode_message(msg)
+    restored = decode_message(data, Pose2D)
+    assert restored == msg
+
+
+def test_to_from_zenoh_value_roundtrip():
+    msg = Pose2D(x=3.0, y=4.0, theta=1.2)
+    data = to_zenoh_value(msg)
+    restored = from_zenoh_value(data, Pose2D)
+    assert restored == msg
+
+
+def test_message_methods():
+    msg = Pose2D(x=5.0, y=6.0, theta=2.0)
+    data = msg.to_bytes()
+    restored = Pose2D.from_bytes(data)
+    assert restored == msg

--- a/tide/models/__init__.py
+++ b/tide/models/__init__.py
@@ -19,6 +19,10 @@ from tide.models.serialization import (
     to_dict,
     to_zenoh_value,
     from_zenoh_value,
+    to_cbor,
+    from_cbor,
+    encode_message,
+    decode_message,
 )
 
 from tide.models.robot import (
@@ -51,6 +55,10 @@ __all__ = [
     'to_dict',
     'to_zenoh_value',
     'from_zenoh_value',
+    'to_cbor',
+    'from_cbor',
+    'encode_message',
+    'decode_message',
     
     # Robot configuration
     'RobotType',

--- a/tide/models/common.py
+++ b/tide/models/common.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, Type
 
 try:
     from pydantic import BaseModel, Field, ConfigDict
@@ -13,8 +13,25 @@ except ImportError:
 class TideMessage(BaseModel):
     """Base class for all messages in the tide framework."""
     timestamp: datetime = Field(default_factory=datetime.now)
-    
+
     model_config = ConfigDict()
+
+    def to_bytes(self) -> bytes:
+        """Serialize this message to CBOR bytes."""
+        from .serialization import to_cbor
+
+        return to_cbor(self)
+
+    def __bytes__(self) -> bytes:  # type: ignore[override]
+        """bytes(obj) returns the CBOR representation."""
+        return self.to_bytes()
+
+    @classmethod
+    def from_bytes(cls: Type['TideMessage'], data: Union[bytes, str]) -> 'TideMessage':
+        """Deserialize bytes into a message instance."""
+        from .serialization import from_cbor
+
+        return from_cbor(data, cls)
 
 
 class Vector2(BaseModel):

--- a/tide/models/serialization.py
+++ b/tide/models/serialization.py
@@ -1,6 +1,8 @@
 import json
 from typing import Any, Dict, Type, TypeVar, Union
 
+import cbor2
+
 try:
     from pydantic import BaseModel
 except ImportError:
@@ -52,7 +54,7 @@ def to_dict(model: Union[BaseModel, Dict]) -> Dict[str, Any]:
         return model
     
     try:
-        return model.model_dump()
+        return model.model_dump(mode="json")
     except (AttributeError, TypeError):
         # Try different approaches for non-models
         try:
@@ -62,46 +64,71 @@ def to_dict(model: Union[BaseModel, Dict]) -> Dict[str, Any]:
             return model.__dict__
 
 
+def to_cbor(model: Union[BaseModel, Dict, Any]) -> bytes:
+    """Convert a model or dictionary to CBOR bytes."""
+
+    if isinstance(model, (bytes, bytearray)):
+        return bytes(model)
+
+    data = json.loads(to_json(model))
+    return cbor2.dumps(data)
+
+
+def from_cbor(data: Union[bytes, str, Any], model_class: Type[T]) -> T:
+    """Decode CBOR data into a model instance.
+
+    `data` may be a byte sequence, string, or any object implementing
+    the ``__bytes__`` protocol (e.g., ``zenoh.ZBytes``).
+    """
+
+    if not isinstance(data, (bytes, bytearray)):
+        if isinstance(data, str):
+            data = data.encode("utf-8")
+        else:
+            try:
+                data = bytes(data)
+            except Exception:
+                raise TypeError("Unsupported data type for CBOR decoding")
+
+    obj = cbor2.loads(data)
+    if model_class == dict:
+        return obj
+
+    try:
+        return model_class.model_validate(obj)
+    except (AttributeError, TypeError):
+        inst = model_class()
+        for k, v in obj.items():
+            setattr(inst, k, v)
+        return inst
+
+
+def encode_message(msg: Union[BaseModel, Dict, Any]) -> bytes:
+    """Convenience wrapper to encode a message to CBOR."""
+
+    return to_cbor(msg)
+
+
+def decode_message(data: Union[bytes, str], model_class: Type[T]) -> T:
+    """Convenience wrapper to decode a message from CBOR."""
+
+    return from_cbor(data, model_class)
+
+
 def to_zenoh_value(model: Union[BaseModel, Dict, Any]) -> bytes:
     """
-    Convert a model or data to bytes for Zenoh transport.
-    
+    Convert a model or data to bytes for Zenoh transport using CBOR.
+
     Args:
         model: Model or data to convert
-        
+
     Returns:
         Bytes representation
     """
-    return to_json(model).encode('utf-8')
+    return to_cbor(model)
 
 
 def from_zenoh_value(data: Union[bytes, str], model_class: Type[T]) -> T:
-    """
-    Create a model from Zenoh data.
-    
-    Args:
-        data: Data received from Zenoh (bytes or string)
-        model_class: Class of the model to create
-        
-    Returns:
-        An instance of the model_class
-    """
-    if isinstance(data, bytes):
-        data = data.decode('utf-8')
-    
-    # If it's a string, parse it as JSON
-    if isinstance(data, str):
-        data = json.loads(data)
-    
-    # If model_class is dict, just return the data
-    if model_class == dict:
-        return data
-    
-    try:
-        return model_class.model_validate(data)
-    except (AttributeError, TypeError):
-        # Fallback if pydantic not available
-        obj = model_class()
-        for k, v in data.items():
-            setattr(obj, k, v)
-        return obj 
+    """Decode a Zenoh payload into the given model type using CBOR."""
+
+    return from_cbor(data, model_class)


### PR DESCRIPTION
## Summary
- implement CBOR encode/decode helpers
- integrate encode/decode into node communication
- expose new helpers via `tide.models`
- add per-message to_bytes/from_bytes convenience methods
- test CBOR helpers
- fix CBOR decoding of Zenoh byte objects

## Testing
- `uv run pytest -q`