### PR TITLE
Add robot topic builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,6 @@
 *.pyzw
 *.jpg
 *.mp4
-*/__pycache__
+.hypothesis/
+*/__pycache__/
+

--- a/docs/namespacing.md
+++ b/docs/namespacing.md
@@ -99,6 +99,10 @@ self.put(rgb_key, to_zenoh_value(rgb_image))
 # Depth images are supported with a helper as well
 depth_key = sensor_camera_depth("front")
 self.put(depth_key, to_zenoh_value(depth_image))
+
+# Build a key for another robot
+cmd_key = robot_topic("otherbot", CmdTopic.TWIST.value)
+z.put(cmd_key, to_zenoh_value(cmd_vel))
 ```
 
 Mappings such as `CMD_TYPES`, `STATE_TYPES`, and `SENSOR_TYPES` allow lookup of the expected message type for each reserved topic.

--- a/tests/test_models/test_reserved_namespaces.py
+++ b/tests/test_models/test_reserved_namespaces.py
@@ -9,6 +9,7 @@ from tide.namespaces import (
     SensorTopic,
     sensor_camera_rgb,
     sensor_camera_depth,
+    robot_topic,
 )
 from tide.models import (
     Vector2,
@@ -124,4 +125,9 @@ def test_reserved_namespace_roundtrip():
         assert received == img
     finally:
         session.close()
+
+
+def test_robot_topic_builder():
+    key = robot_topic("rover", CmdTopic.TWIST.value)
+    assert key == "/rover/cmd/twist"
 

--- a/tide/__init__.py
+++ b/tide/__init__.py
@@ -19,6 +19,7 @@ from tide.namespaces import (
     SensorTopic,
     sensor_camera_rgb,
     sensor_camera_depth,
+    robot_topic,
 )
 
 __all__ = [
@@ -29,5 +30,6 @@ __all__ = [
     "SensorTopic",
     "sensor_camera_rgb",
     "sensor_camera_depth",
+    "robot_topic",
     "PIDNode",
 ]

--- a/tide/namespaces.py
+++ b/tide/namespaces.py
@@ -73,6 +73,12 @@ def sensor_camera_depth(camera_id: str) -> str:
     return f"sensor/camera/{camera_id}/depth"
 
 
+def robot_topic(robot_id: str, topic: str) -> str:
+    """Return an absolute topic in the form ``/{robot_id}/{topic}``."""
+    topic = topic.lstrip("/")
+    return f"/{robot_id}/{topic}"
+
+
 __all__ = [
     "Group",
     "CmdTopic",
@@ -83,4 +89,5 @@ __all__ = [
     "SENSOR_TYPES",
     "sensor_camera_rgb",
     "sensor_camera_depth",
+    "robot_topic",
 ]


### PR DESCRIPTION
## Summary
- add `robot_topic` helper for building `/robot/topic` strings
- export the helper in the public API
- document the function in the namespacing guide
- test new builder
- ignore Hypothesis cache

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_686abde8f8a48330ac2f9934efee2012

## Summary by Sourcery

Add a new `robot_topic` helper for constructing robot-specific topic strings and integrate it into the public API, documentation, and tests, while also updating .gitignore to ignore Hypothesis cache.

New Features:
- Introduce `robot_topic` helper for building absolute `/robot_id/topic` strings.

Enhancements:
- Export `robot_topic` helper in the package’s public API.

Documentation:
- Document `robot_topic` usage in the namespacing guide.

Tests:
- Add a test case for the `robot_topic` builder.

Chores:
- Update .gitignore to ignore Hypothesis cache.