### PR TITLE
Improve CLI status tests

### DIFF
--- a/tests/test_cli/test_cli.py
+++ b/tests/test_cli/test_cli.py
@@ -2,6 +2,8 @@ import argparse
 from types import SimpleNamespace
 from unittest import mock
 
+import zenoh
+
 import pytest
 
 from tide.cli.main import create_parser
@@ -39,13 +41,38 @@ def test_cmd_init_creates_project(tmp_path, monkeypatch):
     assert (proj_dir / 'config' / 'config.yaml').exists()
 
 
-def test_cmd_status(monkeypatch, capsys):
-    monkeypatch.setattr('tide.cli.commands.status.discover_nodes', lambda timeout: [{'robot_id': 'r', 'group': 'g', 'topic': 't'}])
-    args = argparse.Namespace(timeout=0.1)
+def test_cmd_status_no_nodes(capsys):
+    """Status command should report no nodes when none are running."""
+    args = argparse.Namespace(timeout=0.2)
     result = cmd_status(args)
     assert result == 0
     captured = capsys.readouterr()
-    assert 'r' in captured.out
+    assert 'No Tide nodes discovered' in captured.out
+
+
+def test_cmd_status_with_node(capsys):
+    """Status command should list nodes when one is present."""
+    zenoh.init_log_from_env_or('error')
+    session = zenoh.open(zenoh.Config())
+
+    def handler(query):
+        # Respond to the discovery query with a dummy key
+        query.reply('robotA/dummy/ping', b'hello')
+
+    q = session.declare_queryable('robotA/**', handler)
+
+    args = argparse.Namespace(timeout=0.5)
+    result = cmd_status(args)
+
+    q.undeclare()
+    session.close()
+
+    assert result == 0
+    captured = capsys.readouterr()
+    assert 'robotA' in captured.out
+
+
+
 
 
 def test_cmd_up(monkeypatch, tmp_path):
@@ -60,28 +87,22 @@ def test_cmd_up(monkeypatch, tmp_path):
     dummy_node.stop.assert_called()
 
 
-def test_discover_nodes_parses_keys(monkeypatch):
-    class FakeKeyExpr:
-        def __init__(self, key):
-            self._key = key
-        def to_string(self):
-            return self._key
-    class FakeReply:
-        def __init__(self, key):
-            self.ok = SimpleNamespace(key_expr=FakeKeyExpr(key))
-    class FakeSession:
-        def get(self, expr):
-            return [FakeReply('robotA/ping/ping')]
-        def close(self):
-            pass
+def test_discover_nodes_parses_keys():
+    """discover_nodes should parse the key parts from replies."""
+    zenoh.init_log_from_env_or('error')
+    session = zenoh.open(zenoh.Config())
 
-    monkeypatch.setattr('tide.cli.utils.zenoh.open', lambda cfg=None: FakeSession())
+    def handler(query):
+        query.reply('robotA/ping/ping', b'data')
 
-    from importlib import reload
-    import tide.cli.utils as utils
-    reload(utils)
+    q = session.declare_queryable('robotA/**', handler)
 
-    nodes = utils.discover_nodes(timeout=0.1)
+    from tide.cli import utils
+    nodes = utils.discover_nodes(timeout=0.5)
+
+    q.undeclare()
+    session.close()
+
     assert len(nodes) == 1
     assert nodes[0]['robot_id'] == 'robotA'
     assert nodes[0]['group'] == 'ping'

--- a/tide/cli/utils.py
+++ b/tide/cli/utils.py
@@ -116,7 +116,10 @@ def discover_nodes(timeout: float = 2.0) -> List[Dict[str, Any]]:
             # Process any new replies
             for reply in replies:
                 if hasattr(reply, 'ok'):
-                    key_parts = reply.ok.key_expr.to_string().split('/')
+                    # KeyExpr objects in the Python zenoh bindings do not
+                    # implement a `to_string()` method. Casting to `str` works
+                    # across versions, so use that to retrieve the key text.
+                    key_parts = str(reply.ok.key_expr).split('/')
                     if len(key_parts) >= 3:
                         # key_parts contains [robot_id, group, ...]
                         robot_id = key_parts[0]


### PR DESCRIPTION
## Summary
- use real zenoh sessions in CLI tests
- fix discover_nodes to handle KeyExpr without `to_string`

## Testing
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d51630d4c8330a88534ff3548b3a7