### PR TITLE
Add motor topic helpers and models

### DIFF
--- a/docs/motors.md
+++ b/docs/motors.md
@@ -1,0 +1,50 @@
+# Motor Topic Specification
+
+This document describes the reserved Tide topics for controlling and
+monitoring individual motors.
+
+## Topic Pattern
+
+```
+/{robot_id}/motors/{motor_id}/{suffix}
+```
+
+- **robot_id** – name of the robot
+- **motor_id** – numeric identifier for the motor
+- **suffix** – one of `cmd_pos`, `cmd_vel`, `pos`, `vel`
+
+## Message Types
+
+| Suffix | Model | Description |
+|--------|-------|-------------|
+| `cmd_pos` / `pos` | `MotorPosition` | Motor position target or state in full rotations |
+| `cmd_vel` / `vel` | `MotorVelocity` | Motor velocity target or state in rotations per second |
+
+The models are defined in `tide.models`:
+
+```python
+from tide.models import MotorPosition, MotorVelocity
+
+MotorPosition(rotations: float)
+MotorVelocity(rotations_per_sec: float)
+```
+
+## Examples
+
+```python
+from tide.namespaces import motor_cmd_vel
+from tide.models import MotorVelocity, to_zenoh_value
+
+key = motor_cmd_vel(1)
+msg = MotorVelocity(rotations_per_sec=5.0)
+zenoh_session.put(f"/rover/{key}", to_zenoh_value(msg))
+```
+
+```python
+from tide.namespaces import motor_pos
+from tide.models import MotorPosition
+
+# Subscribe to motor position updates for motor 2
+key = motor_pos(2)
+session.declare_subscriber(f"/rover/{key}", lambda s: ...)
+```

--- a/docs/namespacing.md
+++ b/docs/namespacing.md
@@ -66,6 +66,27 @@ The above could publish a custom status object describing the claw
 position or whether it is open or closed. Commands may be sent with
 `manipulator/cmd/claw` or similar topics.
 
+## Motor Topics (`motors`)
+
+Individual motor control and feedback use the `motors` group with a
+numeric motor identifier:
+
+| Topic | Message Type | Description |
+|-------|--------------|-------------|
+| `motors/{id}/cmd_pos` | `MotorPosition` | Set target position in rotations |
+| `motors/{id}/cmd_vel` | `MotorVelocity` | Set target velocity in rotations/sec |
+| `motors/{id}/pos` | `MotorPosition` | Current motor position in rotations |
+| `motors/{id}/vel` | `MotorVelocity` | Current motor velocity in rotations/sec |
+
+Helper functions in `tide.namespaces` build these topics:
+
+```python
+from tide.namespaces import motor_cmd_pos, motor_pos
+
+cmd_key = motor_cmd_pos(1)  # "motors/1/cmd_pos"
+state_key = motor_pos(1)    # "motors/1/pos"
+```
+
 ## Custom Groups
 
 Groups other than the ones listed above are unreserved. Examples used in

--- a/tests/test_components/test_webcam_node.py
+++ b/tests/test_components/test_webcam_node.py
@@ -9,8 +9,7 @@ from tide.config import TideConfig, NodeConfig
 from tide.models.common import Image
 from tide.components.webcam_node import WebcamNode
 
-# Skip tests if OpenCV (or required system libraries) are unavailable
-cv2 = pytest.importorskip("cv2", exc_type=ImportError)
+import cv2
 
 
 CAM = os.getenv("TEST_CAMERA", "/dev/video0")

--- a/tests/test_components/test_webcam_node.py
+++ b/tests/test_components/test_webcam_node.py
@@ -8,7 +8,9 @@ from tide.core.utils import launch_from_config
 from tide.config import TideConfig, NodeConfig
 from tide.models.common import Image
 from tide.components.webcam_node import WebcamNode
-import cv2
+
+# Skip tests if OpenCV (or required system libraries) are unavailable
+cv2 = pytest.importorskip("cv2", exc_type=ImportError)
 
 
 CAM = os.getenv("TEST_CAMERA", "/dev/video0")

--- a/tests/test_models/test_reserved_namespaces.py
+++ b/tests/test_models/test_reserved_namespaces.py
@@ -9,6 +9,10 @@ from tide.namespaces import (
     SensorTopic,
     sensor_camera_rgb,
     sensor_camera_depth,
+    motor_cmd_pos,
+    motor_cmd_vel,
+    motor_pos,
+    motor_vel,
     robot_topic,
 )
 from tide.models import (
@@ -20,6 +24,8 @@ from tide.models import (
     Pose3D,
     LaserScan,
     Image,
+    MotorPosition,
+    MotorVelocity,
 )
 from tide.models.serialization import to_zenoh_value, from_zenoh_value
 
@@ -123,6 +129,20 @@ def test_reserved_namespace_roundtrip():
         key = f"{robot}/" + sensor_camera_depth("front")
         received = _roundtrip(session, key, img, Image)
         assert received == img
+
+        # Motor topics
+        pos_msg = MotorPosition(rotations=1.5)
+        vel_msg = MotorVelocity(rotations_per_sec=2.0)
+        motor_cases = [
+            (motor_cmd_pos, pos_msg, MotorPosition),
+            (motor_cmd_vel, vel_msg, MotorVelocity),
+            (motor_pos, pos_msg, MotorPosition),
+            (motor_vel, vel_msg, MotorVelocity),
+        ]
+        for builder, msg, model in motor_cases:
+            key = f"{robot}/" + builder(1)
+            received = _roundtrip(session, key, msg, model)
+            assert received == msg
     finally:
         session.close()
 

--- a/tide/__init__.py
+++ b/tide/__init__.py
@@ -19,6 +19,10 @@ from tide.namespaces import (
     SensorTopic,
     sensor_camera_rgb,
     sensor_camera_depth,
+    motor_cmd_pos,
+    motor_cmd_vel,
+    motor_pos,
+    motor_vel,
     robot_topic,
 )
 
@@ -30,6 +34,10 @@ __all__ = [
     "SensorTopic",
     "sensor_camera_rgb",
     "sensor_camera_depth",
+    "motor_cmd_pos",
+    "motor_cmd_vel",
+    "motor_pos",
+    "motor_vel",
     "robot_topic",
     "PIDNode",
 ]

--- a/tide/models/__init__.py
+++ b/tide/models/__init__.py
@@ -12,6 +12,8 @@ from tide.models.common import (
     OccupancyGrid2D,
     LaserScan,
     Image,
+    MotorPosition,
+    MotorVelocity,
 )
 
 from tide.models.serialization import (
@@ -49,6 +51,8 @@ __all__ = [
     'OccupancyGrid2D',
     'LaserScan',
     'Image',
+    'MotorPosition',
+    'MotorVelocity',
     
     # Serialization utilities
     'to_json',

--- a/tide/models/common.py
+++ b/tide/models/common.py
@@ -126,4 +126,16 @@ class Image(TideMessage):
     encoding: str  # rgb8, bgr8, mono8, etc.
     is_bigendian: bool = False
     step: int  # Full row length in bytes
-    data: bytes 
+    data: bytes
+
+
+class MotorPosition(TideMessage):
+    """Motor position expressed in full rotations."""
+
+    rotations: float = 0.0
+
+
+class MotorVelocity(TideMessage):
+    """Motor velocity in rotations per second."""
+
+    rotations_per_sec: float = 0.0

--- a/tide/namespaces.py
+++ b/tide/namespaces.py
@@ -73,6 +73,26 @@ def sensor_camera_depth(camera_id: str) -> str:
     return f"sensor/camera/{camera_id}/depth"
 
 
+def motor_cmd_pos(motor_id: int) -> str:
+    """Topic for commanding a motor position in rotations."""
+    return f"motors/{motor_id}/cmd_pos"
+
+
+def motor_cmd_vel(motor_id: int) -> str:
+    """Topic for commanding a motor velocity in rotations/sec."""
+    return f"motors/{motor_id}/cmd_vel"
+
+
+def motor_pos(motor_id: int) -> str:
+    """Topic publishing a motor's current position in rotations."""
+    return f"motors/{motor_id}/pos"
+
+
+def motor_vel(motor_id: int) -> str:
+    """Topic publishing a motor's current velocity in rotations/sec."""
+    return f"motors/{motor_id}/vel"
+
+
 def robot_topic(robot_id: str, topic: str) -> str:
     """Return an absolute topic in the form ``/{robot_id}/{topic}``."""
     topic = topic.lstrip("/")
@@ -89,5 +109,9 @@ __all__ = [
     "SENSOR_TYPES",
     "sensor_camera_rgb",
     "sensor_camera_depth",
+    "motor_cmd_pos",
+    "motor_cmd_vel",
+    "motor_pos",
+    "motor_vel",
     "robot_topic",
 ]


### PR DESCRIPTION
## Summary
- add MotorPosition and MotorVelocity models for rotation-based motor control
- add motor topic builders for commanding and monitoring individual motors
- document motor topics in namespacing guide and new motors spec
- skip webcam integration test when OpenCV system libraries are missing

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae005c73fc8330a2bd422557bc30af

## Summary by Sourcery

Introduce motor control topics and message models, update related documentation, and enhance test stability by conditionally skipping webcam tests when OpenCV is missing

New Features:
- Add MotorPosition and MotorVelocity models for rotation-based motor control
- Add topic builder functions for commanding and monitoring motors (motor_cmd_pos, motor_cmd_vel, motor_pos, motor_vel)

Documentation:
- Document motor topics in the namespacing guide and add a dedicated motors specification

Tests:
- Extend reserved namespace tests to cover motor topics
- Skip webcam integration tests when OpenCV libraries are unavailable