### PR TITLE
Add manual release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Manual Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'New version to release'
+        required: true
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run tests
+        env:
+          PYTHONPATH: .
+        run: uv run pytest -q
+
+      - name: Update version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" pyproject.toml
+          sed -i "s/^__version__ = \".*\"/__version__ = \"${VERSION}\"/" tide/__init__.py
+          sed -i "s/version=\".*\"/version=\"${VERSION}\",/" setup.py
+
+      - name: Commit and tag
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git add pyproject.toml tide/__init__.py setup.py
+          git commit -m "Bump version to ${VERSION}"
+          git tag "v${VERSION}"
+
+      - name: Push changes and tag
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          git push origin HEAD:main
+          git push origin "v${VERSION}"

--- a/release-procedure.md
+++ b/release-procedure.md
@@ -2,6 +2,22 @@
 
 This document outlines the step-by-step process for creating a new release of the tide-sdk package.
 
+## Automated Release
+
+The easiest way to cut a new release is via the **Manual Release** workflow
+found in the GitHub Actions tab. Trigger the workflow and provide the desired
+version (e.g. `0.1.9`). The workflow will:
+
+1. Run the test suite
+2. Bump the version in `pyproject.toml`, `tide/__init__.py`, and `setup.py`
+3. Commit the changes to `main`
+4. Create and push a `vX.Y.Z` tag
+
+Pushing the tag automatically kicks off the existing **Publish Python package**
+workflow which builds the package and uploads it to PyPI using OpenID Connect.
+
+If you prefer to perform the release manually, follow the steps below.
+
 ## Prerequisites
 
 - Ensure you have push access to the repository


### PR DESCRIPTION
## Summary
- add workflow to bump version, tag, and push via workflow_dispatch
- document new automated release procedure

## Testing
- `uv run pytest -q` *(fails: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae09892b9483308fb9c8e61e6666fa

## Summary by Sourcery

Add a GitHub Actions "Manual Release" workflow to automate version bumps, tagging, and pushes, and update the release procedure documentation accordingly.

CI:
- Add manual release workflow for bumping version, tagging, and pushing via workflow_dispatch

Documentation:
- Document the new automated release procedure in release-procedure.md