### PR TITLE
Add gyro velocity sensor namespace

### DIFF
--- a/docs/namespacing.md
+++ b/docs/namespacing.md
@@ -45,6 +45,7 @@ Sensor data is published under the `sensor` group. Common examples include:
 | `sensor/lidar/scan` | `LaserScan` | 2D lidar data |
 | `sensor/imu/accel`  | `Vector3`   | IMU acceleration |
 | `sensor/imu/quat`   | `Quaternion`| IMU orientation as a quaternion |
+| `sensor/imu/gyro_vel` | `Vector3` | IMU angular velocity |
 | `sensor/camera/{camera_id}/rgb` | `Image` | RGB image from the named camera |
 | `sensor/camera/{camera_id}/depth` | `Image` | Depth image from the named camera |
 

--- a/tests/test_models/test_reserved_namespaces.py
+++ b/tests/test_models/test_reserved_namespaces.py
@@ -116,6 +116,10 @@ def test_reserved_namespace_roundtrip():
                 SensorTopic.IMU_QUAT,
                 Quaternion(x=0.0, y=0.0, z=0.0, w=1.0),
             ),
+            (
+                SensorTopic.IMU_GYRO_VEL,
+                Vector3(x=0.4, y=0.5, z=0.6),
+            ),
         ]
 
         for topic, msg in cases:

--- a/tide/namespaces.py
+++ b/tide/namespaces.py
@@ -58,12 +58,14 @@ class SensorTopic(str, Enum):
     LIDAR_SCAN = "sensor/lidar/scan"
     IMU_ACCEL = "sensor/imu/accel"
     IMU_QUAT = "sensor/imu/quat"
+    IMU_GYRO_VEL = "sensor/imu/gyro_vel"
 
 
 SENSOR_TYPES: Dict[SensorTopic, Type] = {
     SensorTopic.LIDAR_SCAN: LaserScan,
     SensorTopic.IMU_ACCEL: Vector3,
     SensorTopic.IMU_QUAT: Quaternion,
+    SensorTopic.IMU_GYRO_VEL: Vector3,
 }
 
 


### PR DESCRIPTION
## Summary
- extend SensorTopic with `sensor/imu/gyro_vel`
- cover gyro velocity round-trip in reserved namespace tests
- document new gyro velocity sensor namespace

## Testing
- `uv run pytest` *(fails: Failed to fetch: https://pypi.org/simple/hypothesis/)*

------
https://chatgpt.com/codex/tasks/task_e_68ae62e3fd7c8330a901e8c9a7a51d7d

## Summary by Sourcery

Add a new gyro velocity sensor namespace to the SensorTopic enum, map it to Vector3, update documentation, and include it in the reserved namespace tests.

New Features:
- Add IMU_GYRO_VEL sensor topic with its Vector3 type mapping

Enhancements:
- Extend SensorTopic enum and SENSOR_TYPES mapping to include gyro velocity

Documentation:
- Document the sensor/imu/gyro_vel namespace in the namespacing guide

Tests:
- Cover the new IMU_GYRO_VEL topic in reserved namespace round-trip tests