### PR TITLE
feat: support external scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,17 +146,19 @@ def main():
     # Load configuration
     config = load_config('config.yaml')
 
-    # Launch nodes
-    nodes = launch_from_config(config)
+    # Launch nodes and external scripts
+    nodes, processes = launch_from_config(config)
 
     try:
-        print(f"Started {len(nodes)} nodes. Press Ctrl+C to exit.")
+        print(f"Started {len(nodes)} nodes and {len(processes)} scripts. Press Ctrl+C to exit.")
         while True:
             time.sleep(1)
     except KeyboardInterrupt:
         print("Interrupted by user")
         for node in nodes:
             node.stop()
+        for proc in processes:
+            proc.terminate()
 
 if __name__ == "__main__":
     main()
@@ -167,6 +169,9 @@ if __name__ == "__main__":
 ```yaml
 session:
   mode: peer  # Mesh network
+
+scripts:
+  - ./tools/my_helper.py
 
 nodes:
   - type: my_package.MyRobotNode

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -269,9 +269,9 @@ def start_tide_nodes():
     # Load Tide configuration
     config = load_config("config/tide_config.yaml")
 
-    # Launch Tide nodes
-    nodes = launch_from_config(config)
-    return nodes
+    # Launch Tide nodes and scripts
+    nodes, processes = launch_from_config(config)
+    return nodes, processes
 ```
 
 ### Custom Node Development

--- a/docs/config_spec.md
+++ b/docs/config_spec.md
@@ -7,6 +7,8 @@ Tide projects are configured using a YAML file describing the Zenoh session and 
 ```yaml
 session:
   mode: peer
+scripts:
+  - ./tools/my_helper.py
 nodes:
   - type: mypackage.MyNode
     name: optional-name
@@ -27,5 +29,10 @@ A list of node definitions. Each item accepts the following fields:
 - **params** (mapping, optional): Parameters passed to the node constructor.
 
 Any unknown keys will raise a validation error when the configuration is loaded.
+
+### `scripts`
+
+List of shell commands to run as separate processes alongside Tide nodes. Each item is a string command.
+The processes receive a termination signal when the Tide project shuts down.
 
 Use `tide.config.load_config()` to read and validate a configuration file. The function returns a `TideConfig` instance which can be passed to `tide.core.utils.launch_from_config()`.

--- a/main.py
+++ b/main.py
@@ -37,17 +37,23 @@ def main():
             print("Configuration looks valid!")
             return 0
             
-        # Launch nodes from config
-        nodes = launch_from_config(config)
-        
-        print(f"Started {len(nodes)} nodes. Press Ctrl+C to exit.")
-        
+        # Launch nodes and scripts from config
+        nodes, processes = launch_from_config(config)
+
+        print(f"Started {len(nodes)} nodes and {len(processes)} scripts. Press Ctrl+C to exit.")
+
         # Set up signal handler for graceful shutdown
         def signal_handler(sig, frame):
             print("Interrupted by user")
             # Stop all nodes
             for node in nodes:
                 node.stop()
+            # Terminate external processes
+            for proc in processes:
+                try:
+                    proc.terminate()
+                except Exception:
+                    pass
             sys.exit(0)
             
         signal.signal(signal.SIGINT, signal_handler)

--- a/tests/test_components/test_webcam_node.py
+++ b/tests/test_components/test_webcam_node.py
@@ -59,7 +59,7 @@ def test_webcam_node_integration():
         ]
     )
 
-    nodes = launch_from_config(cfg)
+    nodes, procs = launch_from_config(cfg)
 
     # Allow some time for the camera to produce a frame
     time.sleep(1.0)
@@ -69,6 +69,8 @@ def test_webcam_node_integration():
     for n in nodes:
         for t in n.threads:
             t.join(timeout=1.0)
+    for p in procs:
+        p.terminate()
 
     recorder = nodes[-1]
     assert getattr(recorder, "received", None), "no frame received"

--- a/tests/test_core/test_config.py
+++ b/tests/test_core/test_config.py
@@ -45,6 +45,7 @@ def test_launch_from_config_with_model(monkeypatch):
 
     monkeypatch.setattr(utils, "create_node", lambda t, p: Dummy(p))
 
-    nodes = utils.launch_from_config(cfg)
+    nodes, procs = utils.launch_from_config(cfg)
     assert len(nodes) == 1
+    assert procs == []
     assert created[0].config == {}

--- a/tests/test_core/test_pid_node.py
+++ b/tests/test_core/test_pid_node.py
@@ -74,7 +74,7 @@ def test_pid_node_basic():
         ]
     )
 
-    nodes = launch_from_config(cfg)
+    nodes, procs = launch_from_config(cfg)
 
     # Allow time for messages to be exchanged
     time.sleep(0.5)
@@ -84,6 +84,8 @@ def test_pid_node_basic():
     for n in nodes:
         for t in n.threads:
             t.join(timeout=1.0)
+    for p in procs:
+        p.terminate()
 
     recorder = nodes[-1]
     assert getattr(recorder, "received", None), "no command published"

--- a/tide/config/__init__.py
+++ b/tide/config/__init__.py
@@ -32,6 +32,7 @@ class TideConfig(BaseModel):
 
     session: SessionConfig = Field(default_factory=SessionConfig)
     nodes: List[NodeConfig] = Field(default_factory=list)
+    scripts: List[str] = Field(default_factory=list, description="Commands to run as external processes")
 
 
 def load_config(source: Union[str, Path, Mapping[str, Any]]) -> TideConfig:

--- a/tide/config/example.yaml
+++ b/tide/config/example.yaml
@@ -1,6 +1,9 @@
 session:
   mode: peer  # Mesh network
 
+scripts:
+  - echo "Starting helper"
+
 nodes:
   - type: examples.simple_robot.SimpleRobotNode
     params:


### PR DESCRIPTION
## Summary
- allow configuring external scripts in `scripts` list
- run commands alongside Tide nodes and terminate them on shutdown
- document new configuration field and add regression tests

## Testing
- `./install-deps.bash`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af81a45d948330a0431210dc809232

## Summary by Sourcery

Add support for managing external scripts alongside Tide nodes, launching them from the new "scripts" configuration, reporting their count in the CLI and main entry points, and ensuring graceful shutdown of both nodes and processes.

New Features:
- Allow configuring external scripts in the "scripts" list and launching them with Tide nodes

Enhancements:
- Update launch_from_config to return subprocess handles and report script counts in up command and main.py
- Enhance shutdown handlers to terminate and kill external script processes alongside nodes

Documentation:
- Document the new "scripts" field in README, config spec, CLI docs, and example YAML

Tests:
- Add regression test to verify external scripts start and stop correctly
- Update existing CLI, component, and core tests to unpack and terminate external processes