### PR TITLE
feat: add project root path helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,20 @@ class MyRobotNode(BaseNode):
         self.put(StateTopic.POSE2D.value, to_zenoh_value(pose))
 ```
 
+### Simplifying Project Imports
+
+Standalone Tide nodes sometimes need to import other modules from the project
+root. Instead of manually manipulating ``sys.path``, use the helper:
+
+```python
+from tide.core.utils import add_project_root_to_path
+
+add_project_root_to_path(__file__)
+```
+
+This mirrors the common pattern
+``sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))``.
+
 ### Launching Nodes
 
 ```python

--- a/tests/test_core/test_utils.py
+++ b/tests/test_core/test_utils.py
@@ -1,6 +1,12 @@
 import math
+import os
+import sys
 
-from tide.core.utils import quaternion_from_euler, euler_from_quaternion
+from tide.core.utils import (
+    quaternion_from_euler,
+    euler_from_quaternion,
+    add_project_root_to_path,
+)
 
 
 def test_quaternion_roundtrip():
@@ -15,3 +21,19 @@ def test_quaternion_roundtrip():
     assert math.isclose(recovered[0], angles[0], abs_tol=1e-6)
     assert math.isclose(recovered[1], angles[1], abs_tol=1e-6)
     assert math.isclose(recovered[2], angles[2], abs_tol=1e-6)
+
+
+def test_add_project_root_to_path(tmp_path):
+    project_root = tmp_path / "project"
+    nodes_dir = project_root / "nodes"
+    nodes_dir.mkdir(parents=True)
+    script = nodes_dir / "dummy.py"
+    script.write_text("", encoding="utf-8")
+
+    added = add_project_root_to_path(str(script))
+    assert added == str(project_root)
+    assert added in sys.path
+
+    # cleanup
+    sys.path.remove(added)
+    assert added not in sys.path

--- a/tide/core/utils.py
+++ b/tide/core/utils.py
@@ -4,6 +4,7 @@ import math
 import os
 import shlex
 import subprocess
+import sys
 from typing import Any, Dict, List, Mapping, Type, Tuple, Optional, Union
 
 from tide.core.geometry import Quaternion
@@ -45,6 +46,29 @@ def import_class(class_path: str) -> Type:
             
             # If we get here, we couldn't find the module
             raise
+
+
+def add_project_root_to_path(file_path: str, levels: int = 2) -> str:
+    """Add an ancestor directory of ``file_path`` to ``sys.path``.
+
+    This mirrors the common pattern used in standalone Tide nodes:
+
+    ``sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))``
+
+    Args:
+        file_path: Typically ``__file__`` from the caller.
+        levels: Number of parent directories to ascend. Defaults to 2.
+
+    Returns:
+        The directory added to ``sys.path``.
+    """
+
+    path = os.path.abspath(file_path)
+    for _ in range(levels):
+        path = os.path.dirname(path)
+    if path not in sys.path:
+        sys.path.append(path)
+    return path
 
 def create_node(node_type: str, params: Dict[str, Any] = None) -> BaseNode:
     """


### PR DESCRIPTION
## Summary
- expose helper to add project root to Python path
- document usage in README
- test path helper

## Testing
- `install-deps.bash`
- `apt-get install -y libgl1`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3ad221ab88330a0f5f5c18c818647