### PR TITLE
Add priority-based MuxNode component

### DIFF
--- a/docs/mux_node.md
+++ b/docs/mux_node.md
@@ -1,0 +1,35 @@
+# MuxNode
+
+The `MuxNode` provides a simple priority-based multiplexer for topics of the
+same message type.  It subscribes to multiple input topics, each assigned a
+priority, and republishes the message from the highest-priority topic that
+produces data.
+
+Lower-priority messages are discarded whenever a higher-priority topic has
+new data. This is useful for commanding robots from multiple sources, such as
+manual teleoperation overriding autonomous navigation commands.
+
+## Configuration
+
+```yaml
+nodes:
+  - type: tide.components.MuxNode
+    params:
+      robot_id: robot
+      inputs:
+        - topic: cmd/teleop
+          priority: 0   # Highest priority
+        - topic: cmd/autonomy
+          priority: 1
+      output_topic: cmd/mux
+      msg_type: tide.models.common.Twist2D
+```
+
+- `inputs` – list of `{topic, priority}` pairs. Smaller numbers have higher
+  priority.
+- `output_topic` – topic where the selected message is published.
+- `msg_type` – (optional) fully qualified name of the Pydantic model used to
+  reconstruct messages before publishing.
+
+Only one message is published per iteration: the highest-priority message that
+was received since the previous step.

--- a/tests/test_components/test_mux_node.py
+++ b/tests/test_components/test_mux_node.py
@@ -1,0 +1,94 @@
+import time
+
+from tide.core.node import BaseNode
+from tide.core.utils import launch_from_config
+from tide.config import TideConfig, NodeConfig
+from tide.models.common import Twist2D, Vector2
+
+
+class ConstantTwistPublisher(BaseNode):
+    """Continuously publish a fixed Twist2D."""
+
+    GROUP = "pub"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        cfg = self.config or {}
+        self.topic = cfg.get("topic", "/robot/cmd")
+        self.value = float(cfg.get("value", 0.0))
+
+    def step(self) -> None:
+        msg = Twist2D(linear=Vector2(x=self.value, y=0.0))
+        self.put(self.topic, msg)
+
+
+class TwistRecorder(BaseNode):
+    """Record incoming Twist2D messages."""
+
+    GROUP = "sub"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        cfg = self.config or {}
+        self.topic = cfg.get("topic", "/robot/cmd/mux")
+        self.received = []
+        self.subscribe(self.topic, self._on_msg)
+
+    def _on_msg(self, data):
+        try:
+            self.received.append(Twist2D.model_validate(data))
+        except Exception:
+            self.received.append(data)
+
+    def step(self) -> None:
+        pass
+
+
+def test_mux_node_priority_selection():
+    cfg = TideConfig(
+        nodes=[
+            NodeConfig(
+                type="tests.test_components.test_mux_node.ConstantTwistPublisher",
+                params={"robot_id": "robot", "topic": "/robot/cmd/teleop", "value": 2.0},
+            ),
+            NodeConfig(
+                type="tests.test_components.test_mux_node.ConstantTwistPublisher",
+                params={"robot_id": "robot", "topic": "/robot/cmd/autonomy", "value": 1.0},
+            ),
+            NodeConfig(
+                type="tide.components.MuxNode",
+                params={
+                    "robot_id": "robot",
+                    "inputs": [
+                        {"topic": "/robot/cmd/teleop", "priority": 0},
+                        {"topic": "/robot/cmd/autonomy", "priority": 1},
+                    ],
+                    "output_topic": "/robot/cmd/mux",
+                    "msg_type": "tide.models.common.Twist2D",
+                    "hz": 20.0,
+                },
+            ),
+            NodeConfig(
+                type="tests.test_components.test_mux_node.TwistRecorder",
+                params={"robot_id": "robot", "topic": "/robot/cmd/mux"},
+            ),
+        ]
+    )
+
+    nodes, procs = launch_from_config(cfg)
+
+    # Allow messages to propagate
+    time.sleep(0.5)
+
+    for n in nodes:
+        n.stop()
+    for n in nodes:
+        for t in n.threads:
+            t.join(timeout=1.0)
+    for p in procs:
+        p.terminate()
+
+    recorder = nodes[-1]
+    assert getattr(recorder, "received", None), "no message received"
+    twists = [m for m in recorder.received if isinstance(m, Twist2D)]
+    assert twists and max(t.linear.x for t in twists) == 2.0

--- a/tide/components/__init__.py
+++ b/tide/components/__init__.py
@@ -3,5 +3,13 @@
 from .pid_node import PIDNode
 from .pose_estimator import PoseEstimatorNode, SE2Estimator, SE3Estimator
 from .webcam_node import WebcamNode
+from .mux_node import MuxNode
 
-__all__ = ["PIDNode", "PoseEstimatorNode", "SE2Estimator", "SE3Estimator", "WebcamNode"]
+__all__ = [
+    "PIDNode",
+    "PoseEstimatorNode",
+    "SE2Estimator",
+    "SE3Estimator",
+    "WebcamNode",
+    "MuxNode",
+]

--- a/tide/components/mux_node.py
+++ b/tide/components/mux_node.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Any, List, Dict, Type
+
+from tide.core.node import BaseNode
+
+try:
+    from pydantic import BaseModel
+except Exception:  # pragma: no cover - pydantic is required for typing but optional at runtime
+    BaseModel = object  # type: ignore
+
+
+class MuxNode(BaseNode):
+    """Priority-based topic multiplexer.
+
+    This node subscribes to multiple input topics that share the same
+    message type and republishes data from the highest-priority topic
+    that has produced a new message.
+
+    Lower-priority messages are discarded whenever a higher-priority
+    topic provides data in the same iteration.
+
+    Parameters in ``config``:
+
+    - ``inputs``: iterable of ``{"topic": str, "priority": int}``
+      mappings. Smaller ``priority`` numbers imply higher priority.
+    - ``output_topic``: topic where the selected message will be
+      published. Defaults to ``"mux"``.
+    - ``msg_type``: optional Pydantic model class or import string used
+      to reconstruct messages from dictionaries before publishing. When
+      omitted, dictionaries are forwarded as-is.
+    """
+
+    GROUP = "mux"
+
+    def __init__(self, *, config: dict | None = None) -> None:
+        super().__init__(config=config)
+        cfg = config or {}
+
+        inputs = cfg.get("inputs")
+        if not inputs:
+            raise ValueError("MuxNode requires an 'inputs' list in the config")
+
+        self.output_topic: str = cfg.get("output_topic", "mux")
+
+        self.inputs: List[Dict[str, Any]] = []
+        for entry in inputs:
+            if isinstance(entry, dict):
+                topic = entry.get("topic")
+                priority = int(entry.get("priority", 0))
+            else:
+                # Support simple tuple/list form (topic, priority)
+                topic, priority = entry  # type: ignore[misc]
+            if topic is None:
+                raise ValueError("Each input must specify a topic")
+            self.inputs.append({"topic": topic, "priority": priority})
+            self.subscribe(topic)
+
+        # Sort once by priority (lower value = higher priority)
+        self.inputs.sort(key=lambda x: x["priority"])
+
+        msg_type = cfg.get("msg_type")
+        if isinstance(msg_type, str):
+            self.msg_type = self._import_string(msg_type)
+        else:
+            self.msg_type = msg_type
+
+    def _import_string(self, path: str) -> Type[Any]:
+        """Import a class from a fully qualified path."""
+        module_name, class_name = path.rsplit(".", 1)
+        module = __import__(module_name, fromlist=[class_name])
+        return getattr(module, class_name)
+
+    def _maybe_convert(self, msg: Any) -> Any:
+        if self.msg_type and isinstance(msg, dict) and issubclass(self.msg_type, BaseModel):
+            try:
+                return self.msg_type.model_validate(msg)
+            except Exception:
+                pass
+        return msg
+
+    def step(self) -> None:
+        published = False
+        for entry in self.inputs:
+            topic = entry["topic"]
+            val = self.take(topic)
+            if val is not None:
+                if not published:
+                    self.put(self.output_topic, self._maybe_convert(val))
+                    published = True
+                # else: higher-priority message already published; discard
+        # Nothing to do if no messages were received this cycle


### PR DESCRIPTION
## Summary
- add MuxNode to mux multiple topics based on priority
- document MuxNode usage and expose in components package
- add unit test for priority selection
- use real zenoh in MuxNode test

## Testing
- `uv run pytest tests/test_components/test_mux_node.py -q`
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3ac5559788330a20e582e37f8436e

## Summary by Sourcery

Introduce a priority-based MuxNode component that subscribes to multiple topics, republishes the highest-priority message each cycle, expose it in the components package, and provide accompanying documentation and tests.

New Features:
- Introduce MuxNode component to multiplex multiple input topics by priority
- Expose MuxNode in the tide.components package

Documentation:
- Add user-facing documentation for MuxNode in docs/mux_node.md

Tests:
- Add integration test to verify MuxNode selects the highest-priority message using real zenoh