### PR TITLE
docs: add uv dev install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,3 +270,11 @@ images.  See [docs/pid_node.md](docs/pid_node.md) and
 ## License
 
 MIT
+
+## Installing Latest Development Version
+
+To try the latest features before they are released on PyPI, install Tide directly from the main branch using `uv`:
+
+```bash
+uv add git+https://github.com/tide-robotics/tide.git@main
+```


### PR DESCRIPTION
## Summary
- explain how to install latest development version directly from main using uv

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7b4d99d108330946f2146562b74ea

## Summary by Sourcery

Documentation:
- Add an "Installing Latest Development Version" section to the README with instructions to install from the main branch via uv